### PR TITLE
chore: git-ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ buildNumber.properties
 # Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
 !/.mvn/wrapper/maven-wrapper.jar
 
+# Local environment / secrets
+.env
+.env.*
+


### PR DESCRIPTION
## Summary

- Adds `.env` and `.env.*` to `.gitignore`
- The Java/Maven template used at project init didn't include this guard; this is a preventive hardening
- No secrets are in use in this repo (no Mongo or other credentials here); this closes out the security audit item

## Audit context (mxfmd/vps#5)

Full-scan findings:
- `blog` remote+history: clean (`.env` in `.gitignore` since init, never committed to any branch or in full `git log --all`)
- `blog` box checkout: `.env` present and correctly ignored (`!! .env`)
- `blog` laptop checkout: `.env` was staged in the index (bypassing `.gitignore`) - unstaged via `git rm --cached .env`; never committed/pushed; no credential rotation needed
- `microservices-lab`: no secrets in use; `.gitignore` guard missing - this PR adds it

## Test plan

- [ ] `git check-ignore .env` returns `.env` after merge
- [ ] No `.env` files appear in `git status` output on a fresh clone