### PR TITLE
fix(observability): expose Prometheus actuator endpoint on all services

### DIFF
--- a/book-recommendation-service/pom.xml
+++ b/book-recommendation-service/pom.xml
@@ -65,6 +65,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-loadbalancer</artifactId>
     </dependency>

--- a/book-recommendation-service/src/main/resources/application.yml
+++ b/book-recommendation-service/src/main/resources/application.yml
@@ -4,3 +4,11 @@ eureka:
   client:
     service-url:
       defaultZone: ${SERVICE_URL_DEFAULT_ZONE:http://localhost:8761/eureka}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/book-service-parent/book-service/pom.xml
+++ b/book-service-parent/book-service/pom.xml
@@ -26,6 +26,10 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-bootstrap</artifactId>
     </dependency>

--- a/book-service-parent/book-service/src/main/resources/application.yml
+++ b/book-service-parent/book-service/src/main/resources/application.yml
@@ -4,3 +4,11 @@ eureka:
   client:
     service-url:
       defaultZone: ${SERVICE_URL_DEFAULT_ZONE:http://localhost:8761/eureka}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/config-service/pom.xml
+++ b/config-service/pom.xml
@@ -22,6 +22,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-config-server</artifactId>
 		</dependency>

--- a/config-service/src/main/resources/application.yml
+++ b/config-service/src/main/resources/application.yml
@@ -8,3 +8,11 @@ spring:
         git:
           uri: https://github.com/mxfmd/microservices-lab.git
           search-paths: config-data
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/discovery-service/pom.xml
+++ b/discovery-service/pom.xml
@@ -26,6 +26,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>jakarta.xml.bind</groupId>
 			<artifactId>jakarta.xml.bind-api</artifactId>
 		</dependency>

--- a/discovery-service/src/main/resources/application.yml
+++ b/discovery-service/src/main/resources/application.yml
@@ -4,3 +4,11 @@ eureka:
     register-with-eureka: false
 server:
   port: 8761
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -22,6 +22,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-gateway</artifactId>
 		</dependency>

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -12,3 +12,11 @@ eureka:
   client:
     service-url:
       defaultZone: ${SERVICE_URL_DEFAULT_ZONE:http://localhost:8761/eureka}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}


### PR DESCRIPTION
## Summary

- Adds `io.micrometer:micrometer-registry-prometheus` (version from Spring Boot BOM) to all five service poms.
- Appends a `management:` block to each service's `application.yml` that exposes `health,info,prometheus` and tags every metric with `application: ${spring.application.name}`.
- `health` is kept in the include list — all five services' Docker healthchecks curl `/actuator/health`, and setting `exposure.include` overrides the Spring Boot default, so omitting it would break `depends_on: service_healthy` container startup.

## Test plan

- [x] `./mvnw clean package` passes (BUILD SUCCESS, 8 tests green, 0 failures)
- [ ] Start dev stack: `docker-compose -f compose.dev.yml up -d`
- [ ] Confirm containers reach `healthy` (proves `/actuator/health` still works after the exposure override)
- [ ] `curl -s localhost:8080/actuator/prometheus | head` returns Prometheus text format, not 404
- [ ] Spot-check one other service: `docker exec <book-service-container> curl -sf localhost:8081/actuator/prometheus | head`
- [ ] Verify `application="gateway"` (or equivalent) appears as a label on metric lines

Closes #43

## Follow-up (out of scope here)
Per the issue: join services to `monitoring-network` and add Prometheus scrape jobs in `mxfmd/vps` (tracks vps#14).